### PR TITLE
Try unstructured grid on ValueError

### DIFF
--- a/src/earthkit/plots/components/subplots.py
+++ b/src/earthkit/plots/components/subplots.py
@@ -396,7 +396,7 @@ class Subplot:
                 mappable = getattr(style, method_name)(
                     self.ax, x_values, y_values, z_values, **kwargs
                 )
-            except TypeError as err:
+            except (TypeError, ValueError) as err:
                 if not grids.is_structured(x_values, y_values):
                     x_values, y_values, z_values = grids.interpolate_unstructured(
                         x_values,


### PR DESCRIPTION
Catching a `TypeError` is not enough, so let's catch `ValueError` as well.

<details><summary>Full error traceback</summary>

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[24], line 1
----> 1 earthkit.plots.quickmap.plot(
      2     ds["q"].sel(level=1).sel(time="2020-07-21T12:00:00"),
      3     x="lon", y="lat",
      4 );

File /lib/python3.12/site-packages/earthkit/plots/quickmap.py:9, in _quickmap.<locals>.wrapper(return_subplot, domain, *args, **kwargs)
      7 figure = Figure()
      8 subplot = figure.add_map(domain=domain)
----> 9 getattr(subplot, function.__name__)(*args, **kwargs)
     10 for method in schema.quickmap_workflow:
     11     getattr(subplot, method)()

File /lib/python3.12/site-packages/earthkit/plots/components/subplots.py:597, in Subplot.plot(self, style, *args, **kwargs)
    595 else:
    596     method = self.block
--> 597 return method(*args, style=style, **kwargs)

File /lib/python3.12/site-packages/earthkit/plots/components/subplots.py:227, in Subplot.plot_3D.<locals>.decorator.<locals>.wrapper(self, data, x, y, z, style, every, **kwargs)
    217 def wrapper(
    218     self,
    219     data=None,
   (...)
    225     **kwargs,
    226 ):
--> 227     return self._extract_plottables(
    228         method_name or method.__name__,
    229         args=tuple(),
    230         data=data,
    231         x=x,
    232         y=y,
    233         z=z,
    234         style=style,
    235         every=every,
    236         extract_domain=extract_domain,
    237         **kwargs,
    238     )

File /lib/python3.12/site-packages/earthkit/plots/components/subplots.py:396, in Subplot._extract_plottables(self, method_name, args, data, x, y, z, style, units, every, source_units, extract_domain, **kwargs)
    392     warnings.warn(
    393         "The 'interpolation_method' argument is only valid for unstructured data."
    394     )
    395 try:
--> 396     mappable = getattr(style, method_name)(
    397         self.ax, x_values, y_values, z_values, **kwargs
    398     )
    399 except TypeError as err:
    400     if not grids.is_structured(x_values, y_values):

File /lib/python3.12/site-packages/earthkit/plots/styles/__init__.py:429, in Style.pcolormesh(self, ax, x, y, values, *args, **kwargs)
    427 kwargs.pop("transform_first", None)
    428 kwargs = {**self.to_pcolormesh_kwargs(values), **kwargs}
--> 429 result = ax.pcolormesh(x, y, values, *args, **kwargs)
    430 return result

File /lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:307, in _add_transform.<locals>.wrapper(self, *args, **kwargs)
    302     raise ValueError(f'Invalid transform: Spherical {func.__name__} '
    303                      'is not supported - consider using '
    304                      'PlateCarree/RotatedPole.')
    306 kwargs['transform'] = transform
--> 307 return func(self, *args, **kwargs)

File /lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:1767, in GeoAxes.pcolormesh(self, *args, **kwargs)
   1756 """
   1757 Add the "transform" keyword to :func:`~matplotlib.pyplot.pcolormesh`.
   1758 
   (...)
   1763 
   1764 """
   1765 # Add in an argument checker to handle Matplotlib's potential
   1766 # interpolation when coordinate wraps are involved
-> 1767 args, kwargs = self._wrap_args(*args, **kwargs)
   1768 result = super().pcolormesh(*args, **kwargs)
   1769 # Wrap the quadrilaterals if necessary

File /lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:1794, in GeoAxes._wrap_args(self, *args, **kwargs)
   1792 X = np.asanyarray(args[0])
   1793 Y = np.asanyarray(args[1])
-> 1794 nrows, ncols = np.asanyarray(args[2]).shape[:2]
   1795 Nx = X.shape[-1]
   1796 Ny = Y.shape[0]

ValueError: not enough values to unpack (expected 2, got 1)
```

</details>